### PR TITLE
Updated link to current HDF5 version.

### DIFF
--- a/external/UseGDAL.cmake
+++ b/external/UseGDAL.cmake
@@ -38,7 +38,7 @@ else()
   else()
     ExternalProject_Add(
       hdf5
-      URL "http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.12.tar.gz"
+      URL "http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.13.tar.gz"
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
Broken install when trying to access old (removed) hdf5 tarball.
